### PR TITLE
jit: add jit_if_available option

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,5 +16,6 @@ members = ["pcre2-sys"]
 
 [dependencies]
 libc = "0.2"
+log = "0.4.5"
 pcre2-sys = { version = "0.1.0", path = "pcre2-sys" }
 thread_local = "0.3.6"

--- a/src/ffi.rs
+++ b/src/ffi.rs
@@ -13,6 +13,19 @@ use pcre2_sys::*;
 
 use error::Error;
 
+/// Returns true if and only if PCRE2 believes that JIT is available.
+pub fn is_jit_available() -> bool {
+    let mut rc: u32 = 0;
+    let error_code = unsafe {
+        pcre2_config_8(PCRE2_CONFIG_JIT, &mut rc as *mut _ as *mut c_void)
+    };
+    if error_code < 0 {
+        // If PCRE2_CONFIG_JIT is a bad option, then there's a bug somewhere.
+        panic!("BUG: {}", Error::jit(error_code));
+    }
+    rc == 1
+}
+
 /// A low level representation of a compiled PCRE2 code object.
 pub struct Code {
     code: *mut pcre2_code_8,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,10 +12,13 @@ are welcome to improve this.
 #![deny(missing_docs)]
 
 extern crate libc;
+#[macro_use]
+extern crate log;
 extern crate pcre2_sys;
 extern crate thread_local;
 
 pub use error::{Error, ErrorKind};
+pub use ffi::is_jit_available;
 
 /**
 PCRE2 regular expressions for matching on arbitrary bytes.


### PR DESCRIPTION
This commit adds a new builder option, `jit_if_available`, that is like
the existing `jit` option, but will silently fall back to the non-JIT
matcher if JIT compilation fails (and will also emit a debug log
message). This is useful for platforms that aren't supported by PCRE2's
JIT.

Fixes #3