### PR TITLE
Make log dependency optional

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,9 @@ members = ["pcre2-sys"]
 
 [dependencies]
 libc = "0.2.46"
-log = "0.4.5"
+log = { version = "0.4.5", optional = true }
 pcre2-sys = { version = "0.2.0", path = "pcre2-sys" }
 thread_local = "1"
+
+[features]
+default = ["log"]

--- a/src/bytes.rs
+++ b/src/bytes.rs
@@ -4,6 +4,7 @@ use std::fmt;
 use std::ops::Index;
 use std::sync::Arc;
 
+#[cfg(feature = "log")]
 use log::debug;
 use pcre2_sys::{
     PCRE2_CASELESS, PCRE2_DOTALL, PCRE2_EXTENDED, PCRE2_MULTILINE,
@@ -160,6 +161,7 @@ impl RegexBuilder {
             }
             JITChoice::Attempt => {
                 if let Err(err) = code.jit_compile() {
+                    #[cfg(feature = "log")]
                     debug!("JIT compilation failed: {}", err);
                 }
             }


### PR DESCRIPTION
This helps reduce dependency count when the project doesn't use [log](https://crates.io/crates/log).