### PR TITLE
Make jobserver dependency optional

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,3 +20,7 @@ libc = "0.2.46"
 log = "0.4.5"
 pcre2-sys = { version = "0.2.0", path = "pcre2-sys" }
 thread_local = "1"
+
+[features]
+default = ["parallel"]
+parallel = ["pcre2-sys/parallel"]

--- a/pcre2-sys/Cargo.toml
+++ b/pcre2-sys/Cargo.toml
@@ -16,5 +16,8 @@ edition = "2018"
 libc = "0.2"
 
 [build-dependencies]
-cc = { version = "1", features = ["parallel"] }
+cc = "1"
 pkg-config = "0.3.13"
+
+[features]
+parallel = ["cc/parallel"]


### PR DESCRIPTION
This is similar to #14. It lets the [jobserver] dependency be removed.

[jobserver]: https://crates.io/crates/jobserver