### PR TITLE
Use pcre2_jit_match if JIT compiled

### DIFF
--- a/src/ffi.rs
+++ b/src/ffi.rs
@@ -416,7 +416,13 @@ impl MatchData {
             subject = EMPTY;
         }
 
-        let rc = pcre2_match_8(
+        let match_func = if code.compiled_jit {
+            pcre2_jit_match_8
+        } else {
+            pcre2_match_8
+        };
+
+        let rc = match_func(
             code.as_ptr(),
             subject.as_ptr(),
             subject.len(),


### PR DESCRIPTION
# Description

From pcre2 documents:

> It is a "fast path" interface to JIT, and it bypasses some of the sanity checks that pcre2_match() applies.

https://www.pcre.org/current/doc/html/pcre2_jit_match.html

After this patch is applied rust-pcre2 uses `pcre2_jit_match` if JIT-compiled, `pcre2_match` otherwise.

# Performance comparison

This change would gain +10-20% performance for regexredux benchmark in [BenchmarksGame](https://benchmarksgame-team.pages.debian.net/benchmarksgame/index.html).

## old version

```console
        Command being timed: "../target/release/regexredux"
        User time (seconds): 4.10
        System time (seconds): 0.15
        Percent of CPU this job got: 223%
        Elapsed (wall clock) time (h:mm:ss or m:ss): 0:01.90
        Average shared text size (kbytes): 0
        Average unshared data size (kbytes): 0
        Average stack size (kbytes): 0
        Average total size (kbytes): 0
        Maximum resident set size (kbytes): 150504
        Average resident set size (kbytes): 0
        Major (requiring I/O) page faults: 0
        Minor (reclaiming a frame) page faults: 50724
        Voluntary context switches: 23
        Involuntary context switches: 27
        Swaps: 0
        File system inputs: 0
        File system outputs: 0
        Socket messages sent: 0
        Socket messages received: 0
        Signals delivered: 0
        Page size (bytes): 4096
        Exit status: 0
```

## New version

```console
        Command being timed: "../target/release/regexredux"
        User time (seconds): 3.83
        System time (seconds): 0.14
        Percent of CPU this job got: 244%
        Elapsed (wall clock) time (h:mm:ss or m:ss): 0:01.62
        Average shared text size (kbytes): 0
        Average unshared data size (kbytes): 0
        Average stack size (kbytes): 0
        Average total size (kbytes): 0
        Maximum resident set size (kbytes): 150368
        Average resident set size (kbytes): 0
        Major (requiring I/O) page faults: 0
        Minor (reclaiming a frame) page faults: 50718
        Voluntary context switches: 22
        Involuntary context switches: 14
        Swaps: 0
        File system inputs: 0
        File system outputs: 0
        Socket messages sent: 0
        Socket messages received: 0
        Signals delivered: 0
        Page size (bytes): 4096
        Exit status: 0
```