### PR TITLE
adding replace_all, replace_n, and split functions 

### DIFF
--- a/src/bytes.rs
+++ b/src/bytes.rs
@@ -22,7 +22,8 @@ use crate::ffi::{Code, CompileContext, MatchConfig, MatchData};
 /// of the subject string.
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub struct Match<'s> {
-    subject: &'s [u8],
+    ///subject
+    pub subject: &'s [u8],
     start: usize,
     end: usize,
 }

--- a/src/bytes.rs
+++ b/src/bytes.rs
@@ -567,7 +567,7 @@ impl Regex {
             new.extend_from_slice(&text[last_match..]);
             return Cow::Owned(new);
         }
-
+    
         // The slower path, which we use if the replacement needs access to
         // capture groups.
         let mut it = self.captures_iter(text).enumerate().peekable();
@@ -595,6 +595,19 @@ impl Regex {
         Cow::Owned(new)
     }
 
+    /// Replaces all non-overlapping matches in `text` with the replacement
+    /// provided. This is the same as calling `replacen` with `limit` set to
+    /// `0`.
+    ///
+    /// See the documentation for `replace` for details on how to access
+    /// capturing group matches in the replacement text.
+    pub fn replace_all<'t, R: Replacer>(
+        &self,
+        text: &'t [u8],
+        rep: R,
+    ) -> Cow<'t, [u8]> {
+        self.replacen(text, 0, rep)
+    }
 
     
 

--- a/src/bytes.rs
+++ b/src/bytes.rs
@@ -527,7 +527,26 @@ impl Regex {
             last_match: None,
         }
     }
-    ///splits regex or smth 
+    /// Returns an iterator of substrings of `text` delimited by a match of the
+    /// regular expression. Namely, each element of the iterator corresponds to
+    /// text that *isn't* matched by the regular expression.
+    ///
+    /// This method will *not* copy the text given.
+    ///
+    /// # Example
+    ///
+    /// To split a string delimited by arbitrary amounts of spaces or tabs:
+    ///
+    /// ```rust
+    /// # use regex::bytes::Regex;
+    /// # fn main() {
+    /// let re = Regex::new(r"[ \t]+").unwrap();
+    /// let fields: Vec<&[u8]> = re.split(b"a b \t  c\td    e").collect();
+    /// assert_eq!(fields, vec![
+    ///     &b"a"[..], &b"b"[..], &b"c"[..], &b"d"[..], &b"e"[..],
+    /// ]);
+    /// # }
+    /// ```
     pub fn split<'r, 't>(&'r self, text: &'t [u8]) -> Split<'r, 't> {
         Split { finder: self.find_iter(text), last: 0 }
     }

--- a/src/bytes.rs
+++ b/src/bytes.rs
@@ -64,9 +64,7 @@ impl<'s> Match<'s> {
         (self.start, self.end)
     }
 }
-///splitting
-/// test this  
-/// 
+///Split 
 #[derive(Clone)]
 pub struct Split<'r, 't> {
     finder: Matches<'r, 't>,
@@ -74,7 +72,6 @@ pub struct Split<'r, 't> {
 }
 
 impl<'r, 't> Iterator for Split<'r, 't> {
-
     type Item = Result< &'t [u8], Error>;
     fn next(&mut self) -> Option<Result< &'t [u8], Error>> {
         let text = self.finder.subject;

--- a/src/bytes.rs
+++ b/src/bytes.rs
@@ -25,7 +25,6 @@ use crate::ffi::{Code, CompileContext, MatchConfig, MatchData};
 /// of the subject string.
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub struct Match<'s> {
-    ///subject
     subject: &'s [u8],
     start: usize,
     end: usize,

--- a/src/bytes.rs
+++ b/src/bytes.rs
@@ -26,7 +26,7 @@ use crate::ffi::{Code, CompileContext, MatchConfig, MatchData};
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub struct Match<'s> {
     ///subject
-    pub subject: &'s [u8],
+    subject: &'s [u8],
     start: usize,
     end: usize,
 }
@@ -48,6 +48,11 @@ impl<'s> Match<'s> {
     #[inline]
     pub fn as_bytes(&self) -> &'s [u8] {
         &self.subject[self.start..self.end]
+    }
+    /// Returns the matched portion of the subject string.
+    #[inline]
+    pub fn subject(&self) -> &'s [u8] {
+        &self.subject
     }
 
     /// Creates a new match from the given subject string and byte offsets.

--- a/src/expand.rs
+++ b/src/expand.rs
@@ -1,0 +1,198 @@
+use std::str;
+
+use crate::find_bytes::find_byte;
+
+use crate::bytes;
+
+
+
+pub fn expand_bytes(
+    caps: &bytes::Captures<'_>,
+    mut replacement: &[u8],
+    dst: &mut Vec<u8>,
+) {
+    while !replacement.is_empty() {
+        match find_byte(b'$', replacement) {
+            None => break,
+            Some(i) => {
+                dst.extend(&replacement[..i]);
+                replacement = &replacement[i..];
+            }
+        }
+        if replacement.get(1).map_or(false, |&b| b == b'$') {
+            dst.push(b'$');
+            replacement = &replacement[2..];
+            continue;
+        }
+        debug_assert!(!replacement.is_empty());
+        let cap_ref = match find_cap_ref(replacement) {
+            Some(cap_ref) => cap_ref,
+            None => {
+                dst.push(b'$');
+                replacement = &replacement[1..];
+                continue;
+            }
+        };
+        replacement = &replacement[cap_ref.end..];
+        match cap_ref.cap {
+            Ref::Number(i) => {
+                dst.extend(caps.get(i).map(|m| m.as_bytes()).unwrap_or(b""));
+            }
+            Ref::Named(name) => {
+                dst.extend(
+                    caps.name(name).map(|m| m.as_bytes()).unwrap_or(b""),
+                );
+            }
+        }
+    }
+    dst.extend(replacement);
+}
+
+/// `CaptureRef` represents a reference to a capture group inside some text.
+/// The reference is either a capture group name or a number.
+///
+/// It is also tagged with the position in the text following the
+/// capture reference.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+struct CaptureRef<'a> {
+    cap: Ref<'a>,
+    end: usize,
+}
+
+/// A reference to a capture group in some text.
+///
+/// e.g., `$2`, `$foo`, `${foo}`.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum Ref<'a> {
+    Named(&'a str),
+    Number(usize),
+}
+
+impl<'a> From<&'a str> for Ref<'a> {
+    fn from(x: &'a str) -> Ref<'a> {
+        Ref::Named(x)
+    }
+}
+
+impl From<usize> for Ref<'static> {
+    fn from(x: usize) -> Ref<'static> {
+        Ref::Number(x)
+    }
+}
+
+/// Parses a possible reference to a capture group name in the given text,
+/// starting at the beginning of `replacement`.
+///
+/// If no such valid reference could be found, None is returned.
+fn find_cap_ref(replacement: &[u8]) -> Option<CaptureRef<'_>> {
+    let mut i = 0;
+    let rep: &[u8] = replacement;
+    if rep.len() <= 1 || rep[0] != b'$' {
+        return None;
+    }
+    i += 1;
+    if rep[i] == b'{' {
+        return find_cap_ref_braced(rep, i + 1);
+    }
+    let mut cap_end = i;
+    while rep.get(cap_end).copied().map_or(false, is_valid_cap_letter) {
+        cap_end += 1;
+    }
+    if cap_end == i {
+        return None;
+    }
+    // We just verified that the range 0..cap_end is valid ASCII, so it must
+    // therefore be valid UTF-8. If we really cared, we could avoid this UTF-8
+    // check via an unchecked conversion or by parsing the number straight from
+    // &[u8].
+    let cap =
+        str::from_utf8(&rep[i..cap_end]).expect("valid UTF-8 capture name");
+    Some(CaptureRef {
+        cap: match cap.parse::<u32>() {
+            Ok(i) => Ref::Number(i as usize),
+            Err(_) => Ref::Named(cap),
+        },
+        end: cap_end,
+    })
+}
+
+fn find_cap_ref_braced(rep: &[u8], mut i: usize) -> Option<CaptureRef<'_>> {
+    let start = i;
+    while rep.get(i).map_or(false, |&b| b != b'}') {
+        i += 1;
+    }
+    if !rep.get(i).map_or(false, |&b| b == b'}') {
+        return None;
+    }
+    // When looking at braced names, we don't put any restrictions on the name,
+    // so it's possible it could be invalid UTF-8. But a capture group name
+    // can never be invalid UTF-8, so if we have invalid UTF-8, then we can
+    // safely return None.
+    let cap = match str::from_utf8(&rep[start..i]) {
+        Err(_) => return None,
+        Ok(cap) => cap,
+    };
+    Some(CaptureRef {
+        cap: match cap.parse::<u32>() {
+            Ok(i) => Ref::Number(i as usize),
+            Err(_) => Ref::Named(cap),
+        },
+        end: i + 1,
+    })
+}
+
+/// Returns true if and only if the given byte is allowed in a capture name.
+fn is_valid_cap_letter(b: u8) -> bool {
+    match b {
+        b'0'..=b'9' | b'a'..=b'z' | b'A'..=b'Z' | b'_' => true,
+        _ => false,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{find_cap_ref, CaptureRef};
+
+    macro_rules! find {
+        ($name:ident, $text:expr) => {
+            #[test]
+            fn $name() {
+                assert_eq!(None, find_cap_ref($text.as_bytes()));
+            }
+        };
+        ($name:ident, $text:expr, $capref:expr) => {
+            #[test]
+            fn $name() {
+                assert_eq!(Some($capref), find_cap_ref($text.as_bytes()));
+            }
+        };
+    }
+
+    macro_rules! c {
+        ($name_or_number:expr, $pos:expr) => {
+            CaptureRef { cap: $name_or_number.into(), end: $pos }
+        };
+    }
+
+    find!(find_cap_ref1, "$foo", c!("foo", 4));
+    find!(find_cap_ref2, "${foo}", c!("foo", 6));
+    find!(find_cap_ref3, "$0", c!(0, 2));
+    find!(find_cap_ref4, "$5", c!(5, 2));
+    find!(find_cap_ref5, "$10", c!(10, 3));
+    // See https://github.com/rust-lang/regex/pull/585
+    // for more on characters following numbers
+    find!(find_cap_ref6, "$42a", c!("42a", 4));
+    find!(find_cap_ref7, "${42}a", c!(42, 5));
+    find!(find_cap_ref8, "${42");
+    find!(find_cap_ref9, "${42 ");
+    find!(find_cap_ref10, " $0 ");
+    find!(find_cap_ref11, "$");
+    find!(find_cap_ref12, " ");
+    find!(find_cap_ref13, "");
+    find!(find_cap_ref14, "$1-$2", c!(1, 2));
+    find!(find_cap_ref15, "$1_$2", c!("1_", 3));
+    find!(find_cap_ref16, "$x-$y", c!("x", 2));
+    find!(find_cap_ref17, "$x_$y", c!("x_", 3));
+    find!(find_cap_ref18, "${#}", c!("#", 4));
+    find!(find_cap_ref19, "${Z[}", c!("Z[", 5));
+}

--- a/src/find_bytes.rs
+++ b/src/find_bytes.rs
@@ -1,0 +1,18 @@
+/// Searches for the given needle in the given haystack.
+///
+/// If the perf-literal feature is enabled, then this uses the super optimized
+/// memchr crate. Otherwise, it uses the naive byte-at-a-time implementation.
+pub fn find_byte(needle: u8, haystack: &[u8]) -> Option<usize> {
+    #[cfg(not(feature = "perf-literal"))]
+    fn imp(needle: u8, haystack: &[u8]) -> Option<usize> {
+        haystack.iter().position(|&b| b == needle)
+    }
+
+    #[cfg(feature = "perf-literal")]
+    fn imp(needle: u8, haystack: &[u8]) -> Option<usize> {
+        use memchr::memchr;
+        memchr(needle, haystack)
+    }
+
+    imp(needle, haystack)
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -20,3 +20,5 @@ PCRE2 regular expressions for matching on arbitrary bytes.
 pub mod bytes;
 mod error;
 mod ffi;
+mod expand; 
+mod find_bytes; 


### PR DESCRIPTION
adding replace_all, replace_n, and split functions 
replicated logic from re_bytes.rs from the rust/regex crate
