### PR TITLE
chore: migrate bindgen install hint to bindgen-cli (since 0.61.0)

### DIFF
--- a/pcre2-sys/generate-bindings
+++ b/pcre2-sys/generate-bindings
@@ -5,7 +5,7 @@
 
 if ! command -V bindgen > /dev/null 2>&1; then
     echo "bindgen must be installed" >&2
-    echo "to install: cargo install bindgen" >&2
+    echo "to install: cargo install bindgen-cli" >&2
     exit 1
 fi
 if ! [ -f "$PCRE2SYS_HEADER" ]; then


### PR DESCRIPTION
Since [bindgen 0.61.0][changelog], the `bindgen`
CLI binary must be installed via the `bindgen-cli` crate.

[changelog]: https://github.com/rust-lang/rust-bindgen/blob/main/CHANGELOG.md#0610