### PR TITLE
pcre2: fix test failures on targets that don't support JIT

### DIFF
--- a/src/bytes.rs
+++ b/src/bytes.rs
@@ -1343,7 +1343,7 @@ mod tests {
         let re = RegexBuilder::new()
             .extended(true)
             .utf(true)
-            .jit(true)
+            .jit_if_available(true)
             .build(pattern)
             .unwrap();
         let matched = re.find(hay.as_bytes()).unwrap().unwrap();
@@ -1364,7 +1364,7 @@ mod tests {
         let re = RegexBuilder::new()
             .extended(true)
             .utf(true)
-            .jit(true)
+            .jit_if_available(true)
             .build(pattern)
             .unwrap();
         let matched = re.find(hay.as_bytes()).unwrap().unwrap();


### PR DESCRIPTION
This commit uses `jit_if_available` instead of `jit` in the tests, allowing them to fall back to non-JIT compilation on targets that don't support JIT.