### PR TITLE
Fix handling of empty matches in iterators, using PCRE2_NOTEMPTY_ATSTART

### DIFF
--- a/src/bytes.rs
+++ b/src/bytes.rs
@@ -1044,8 +1044,11 @@ impl<'r, 's> Iterator for CaptureMatches<'r, 's> {
             return None;
         }
         let mut locs = self.re.capture_locations();
-        let res =
-            self.re.captures_read_at(&mut locs, self.subject, self.last_end);
+        let res = self.re.find_at_with_match_data(
+            &mut locs.data,
+            self.subject,
+            self.last_end,
+        );
         let m = match res {
             Err(err) => return Some(Err(err)),
             Ok(None) => return None,

--- a/src/bytes.rs
+++ b/src/bytes.rs
@@ -644,7 +644,7 @@ impl Regex {
     #[inline(always)]
     fn find_at_with_match_data<'s>(
         &self,
-        match_data: &mut MatchDataPoolGuard<'_>,
+        match_data: &mut MatchData,
         subject: &'s [u8],
         start: usize,
     ) -> Result<Option<Match<'s>>, Error> {
@@ -695,21 +695,7 @@ impl Regex {
         subject: &'s [u8],
         start: usize,
     ) -> Result<Option<Match<'s>>, Error> {
-        assert!(
-            start <= subject.len(),
-            "start ({}) must be <= subject.len() ({})",
-            start,
-            subject.len()
-        );
-
-        let options = 0;
-        // SAFETY: We don't use any dangerous PCRE2 options.
-        if unsafe { !locs.data.find(&self.code, subject, start, options)? } {
-            return Ok(None);
-        }
-        let ovector = locs.data.ovector();
-        let (s, e) = (ovector[0], ovector[1]);
-        Ok(Some(Match::new(&subject, s, e)))
+        self.find_at_with_match_data(&mut locs.data, subject, start)
     }
 }
 

--- a/src/bytes.rs
+++ b/src/bytes.rs
@@ -1292,6 +1292,70 @@ mod tests {
     }
 
     #[test]
+    fn iter_empty_mixed() {
+        let re = Regex::new(r"x*y*").unwrap();
+        assert_eq!(
+            find_iter_tuples(&re, b("ÁxyxyÁA")),
+            vec![(0, 0), (1, 1), (2, 4), (4, 6), (7, 7), (8, 8), (9, 9)]
+        );
+        assert_eq!(
+            cap_iter_tuples(&re, b("ÁxyxyÁA")),
+            vec![(0, 0), (1, 1), (2, 4), (4, 6), (7, 7), (8, 8), (9, 9)]
+        );
+        assert_eq!(
+            find_iter_tuples(&re, b"xy\x80\x80xy"),
+            vec![(0, 2), (3, 3), (4, 6)]
+        );
+        assert_eq!(
+            cap_iter_tuples(&re, b"xy\x80\x80xy"),
+            vec![(0, 2), (3, 3), (4, 6)]
+        );
+    }
+
+    #[test]
+    fn iter_empty_mixed_utf() {
+        let re = RegexBuilder::new().utf(true).build(r"x*y*").unwrap();
+        assert_eq!(
+            find_iter_tuples(&re, b("ÁxyxyÁA")),
+            vec![(0, 0), (2, 4), (4, 6), (8, 8), (9, 9)]
+        );
+        assert_eq!(
+            cap_iter_tuples(&re, b("ÁxyxyÁA")),
+            vec![(0, 0), (2, 4), (4, 6), (8, 8), (9, 9)]
+        );
+        assert!(re.find_iter(b"xy\x80\x80xy").next().unwrap().is_err());
+        assert!(re.captures_iter(b"xy\x80\x80xy").next().unwrap().is_err());
+    }
+
+    #[test]
+    fn iter_empty_mixed_ucp() {
+        let re = RegexBuilder::new().ucp(true).build(r"x*y*").unwrap();
+        assert_eq!(
+            find_iter_tuples(&re, b("ÁxyxyÁA")),
+            vec![(0, 0), (2, 4), (4, 6), (8, 8), (9, 9)]
+        );
+        assert_eq!(
+            cap_iter_tuples(&re, b("ÁxyxyÁA")),
+            vec![(0, 0), (2, 4), (4, 6), (8, 8), (9, 9)]
+        );
+        assert_eq!(
+            find_iter_tuples(&re, b"xy\x80\x80xy"),
+            vec![(0, 2), (4, 6)]
+        );
+        assert_eq!(
+            cap_iter_tuples(&re, b"xy\x80\x80xy"),
+            vec![(0, 2), (4, 6)]
+        );
+    }
+
+    #[test]
+    fn iter_lookbehind_ucp() {
+        let re = RegexBuilder::new().ucp(true).build(r"(?<=á)").unwrap();
+        assert_eq!(find_iter_tuples(&re, b("áá")), vec![(2, 2), (4, 4)]);
+        assert_eq!(cap_iter_tuples(&re, b("áá")), vec![(2, 2), (4, 4)]);
+    }
+
+    #[test]
     fn max_jit_stack_size_does_something() {
         if !is_jit_available() {
             return;

--- a/src/bytes.rs
+++ b/src/bytes.rs
@@ -6,7 +6,8 @@ use std::{
 
 use pcre2_sys::{
     PCRE2_CASELESS, PCRE2_DOTALL, PCRE2_EXTENDED, PCRE2_MATCH_INVALID_UTF,
-    PCRE2_MULTILINE, PCRE2_NEWLINE_ANYCRLF, PCRE2_UCP, PCRE2_UNSET, PCRE2_UTF,
+    PCRE2_MULTILINE, PCRE2_NEWLINE_ANYCRLF, PCRE2_NOTEMPTY_ATSTART, PCRE2_UCP,
+    PCRE2_UNSET, PCRE2_UTF,
 };
 
 use crate::{
@@ -352,7 +353,11 @@ impl RegexBuilder {
 
 /// Options that apply to a "find" operation.
 #[derive(Clone, Copy, Default)]
-struct FindOptions {}
+struct FindOptions {
+    /// Ignore an empty match if it occurs at the start position
+    /// (PCRE2_NOTEMPTY_ATSTART).
+    notempty_atstart: bool,
+}
 
 /// A compiled PCRE2 regular expression.
 ///
@@ -664,7 +669,10 @@ impl Regex {
             subject.len()
         );
 
-        let options = 0;
+        let mut options = 0;
+        if find_options.notempty_atstart {
+            options |= PCRE2_NOTEMPTY_ATSTART;
+        }
         // SAFETY: We don't use any dangerous PCRE2 options.
         if unsafe { !match_data.find(&self.code, subject, start, options)? } {
             return Ok(None);

--- a/src/bytes.rs
+++ b/src/bytes.rs
@@ -350,6 +350,10 @@ impl RegexBuilder {
     }
 }
 
+/// Options that apply to a "find" operation.
+#[derive(Clone, Copy, Default)]
+struct FindOptions {}
+
 /// A compiled PCRE2 regular expression.
 ///
 /// This regex is safe to use from multiple threads simultaneously. For top
@@ -631,8 +635,12 @@ impl Regex {
         start: usize,
     ) -> Result<Option<Match<'s>>, Error> {
         let mut match_data = self.match_data();
-        let res =
-            self.find_at_with_match_data(&mut match_data, subject, start);
+        let res = self.find_at_with_match_data(
+            &mut match_data,
+            subject,
+            start,
+            FindOptions::default(),
+        );
         PoolGuard::put(match_data);
         res
     }
@@ -647,6 +655,7 @@ impl Regex {
         match_data: &mut MatchData,
         subject: &'s [u8],
         start: usize,
+        find_options: FindOptions,
     ) -> Result<Option<Match<'s>>, Error> {
         assert!(
             start <= subject.len(),
@@ -695,7 +704,12 @@ impl Regex {
         subject: &'s [u8],
         start: usize,
     ) -> Result<Option<Match<'s>>, Error> {
-        self.find_at_with_match_data(&mut locs.data, subject, start)
+        self.find_at_with_match_data(
+            &mut locs.data,
+            subject,
+            start,
+            FindOptions::default(),
+        )
     }
 }
 
@@ -998,6 +1012,7 @@ impl<'r, 's> Iterator for Matches<'r, 's> {
             &mut self.match_data,
             self.subject,
             self.last_end,
+            FindOptions::default(),
         );
         let m = match res {
             Err(err) => return Some(Err(err)),
@@ -1048,6 +1063,7 @@ impl<'r, 's> Iterator for CaptureMatches<'r, 's> {
             &mut locs.data,
             self.subject,
             self.last_end,
+            FindOptions::default(),
         );
         let m = match res {
             Err(err) => return Some(Err(err)),


### PR DESCRIPTION
The `find_iter` and `captures_iter` functions iterate over the distinct, non-overlapping matches within the subject string.

Previously, this required tricky logic to ensure that the iterator would make forward progress.  In particular, if the previous match was an empty match at byte position J, the next search would start at position J+1.

That didn't work correctly if the regex was in UTF or UCP mode.  For example, if the pattern was `(?<=á)` and the subject string was `áá`:

- In "match-invalid-UTF" mode, trying to search at position 3 would fail to find the match at position 4 (because the byte at position 3 was regarded as invalid).

- In "non-match-invalid-UTF" mode, trying to search at position 3 would give an error ("bad offset into UTF string").

PCRE2 has a mechanism to do what we really want: search for the next match that has `start >= J` and does *not* have `start == end == J`.  This is done by setting the PCRE2_NOTEMPTY_ATSTART flag.

This PR is, I think, a better solution to the problem than my original PR #36.  It avoids making assumptions about what the acceptable matching positions are, by deferring to PCRE2.

