### PR TITLE
Fix/always build static

### DIFF
--- a/pcre2-sys/build.rs
+++ b/pcre2-sys/build.rs
@@ -38,6 +38,7 @@ fn main() {
     // this in lieu of patching config.h since it's easier.
     let mut builder = cc::Build::new();
     builder
+        .define("LINK_SIZE", "4")
         .define("PCRE2_CODE_UNIT_WIDTH", "8")
         .define("HAVE_STDLIB_H", "1")
         .define("HAVE_MEMMOVE", "1")

--- a/pcre2-sys/build.rs
+++ b/pcre2-sys/build.rs
@@ -104,7 +104,6 @@ fn pcre2_sys_static() -> Option<bool> {
 //   ld: symbol(s) not found for architecture arm64
 //
 // aarch64-apple-tvos         https://bugreports.qt.io/browse/QTBUG-62993?gerritReviewStatus=All
-// aarch64-apple-darwin       https://github.com/Homebrew/homebrew-core/pull/57419
 // x86_64-apple-ios           disabled for device–simulator consistency (not tested)
 // x86_64-apple-tvos          disabled for device–simulator consistency (not tested)
 // armv7-apple-ios            assumed equivalent to aarch64-apple-ios (not tested)
@@ -120,9 +119,6 @@ fn pcre2_sys_static() -> Option<bool> {
 // they may end up propagating to all `aarch64`-based targets and the `x86_64`
 // equivalents.
 fn enable_jit(target: &str, builder: &mut cc::Build) {
-    if target.starts_with("aarch64-apple") {
-        return;
-    }
     if target == "aarch64-linux-android" {
         return;
     }


### PR DESCRIPTION
Since we need a PCRE2 configuration that is incompatible with standard system `libpcre2` we always need to build a static `pcre2-sys` library from source.